### PR TITLE
Item index

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
   # before_action :move_to_index, except: [:index]
   def index
+    @item = Item.all.includes(:user).order("created_at DESC")
   end
 
   def edit

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
   # before_action :move_to_index, except: [:index]
   def index
-    @item = Item.all.includes(:user).order("created_at DESC")
+    @item = Item.all.includes(:user).order('created_at DESC')
   end
 
   def edit

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,7 +126,7 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <%# 商品のインスタンス変数になにか入っている場合、商品を一覧表示 %>
       <% unless @item.nil? %>
         <% @item.each do |item| %>
           <li class='list'>
@@ -134,13 +134,13 @@
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
 
-              <%# 商品が売れていればsold outを表示しましょう %>
+              <%# 商品が売れていればsold outを表示 %>
               <% if @item.empty? %>
                 <div class='sold-out'>
                   <span>Sold Out!!</span>
                 </div>
               <% end %>
-              <%# //商品が売れていればsold outを表示しましょう %>
+              <%# //商品が売れていればsold outを表示 %>
 
             </div>
             <div class='item-info'>
@@ -158,10 +158,9 @@
             <% end %>
           </li>
         <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <%# 商品のインスタンス変数になにか入っている場合、商品を一覧表示 %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <%# 商品がない場合は以下のダミー商品を表示 %>
       <% else %>
           <li class='list'>
           <%= link_to '#' do %>
@@ -181,10 +180,10 @@
           <% end %>
           </li>
       <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <%# //商品がない場合は以下のダミー商品を表示 %>
     </ul>
   </div>
+  
   <%# /商品一覧 %>
 </div>
 <%= link_to( new_item_path, class: 'purchase-btn') do %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,53 +127,60 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+      <% unless @item.nil? %>
+        <% @item.each do |item| %>
+          <li class='list'>
+            <%= link_to "#" do %><%#ここは詳細ページ実装後#%>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <% if @item.empty? %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+              <% end %>
+              <%# //商品が売れていればsold outを表示しましょう %>
 
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
             </div>
-          </div>
-        </div>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br><%= item.burden.name %></span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+            <% end %>
+          </li>
         <% end %>
-      </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% else %>
+          <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
+          <% end %>
+          </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,11 +123,11 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、商品を一覧表示 %>
-      <% unless @item.nil? %>
+      <% unless @item.nil? || @item.empty? %>
         <% @item.each do |item| %>
           <li class='list'>
             <%= link_to "#" do %><%#ここは詳細ページ実装後#%>
@@ -159,9 +159,8 @@
           </li>
         <% end %>
       <%# 商品のインスタンス変数になにか入っている場合、商品を一覧表示 %>
-
-      <%# 商品がない場合は以下のダミー商品を表示 %>
       <% else %>
+      <%# 商品がない場合は以下のダミー商品を表示 %>
           <li class='list'>
           <%= link_to '#' do %>
           <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -183,7 +182,7 @@
       <%# //商品がない場合は以下のダミー商品を表示 %>
     </ul>
   </div>
-  
+
   <%# /商品一覧 %>
 </div>
 <%= link_to( new_item_path, class: 'purchase-btn') do %>


### PR DESCRIPTION
# What
- 出品した商品の一覧表示ができていること
- 上から、出品された日時が新しい順に表示されること
-  ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
   - [上記gyazo](https://gyazo.com/408e63fbebb2c90fe8a3e78670273f24)
- 出品した商品が存在しない場合の画面表示
  - [上記gyazo](https://gyazo.com/8b76d101f44915d9cb06734ead99ce61)
- 商品が売れた場合の挙動確認(機能は未実装)
  - [上記gyazo](https://gyazo.com/581bdcfa4f19c59af440eb179219fff8) 

# Why
- 出品された商品はトップページに一覧表示するため