### PR TITLE
item：詳細ページ実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,6 +25,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
       <% unless @item.nil? || @item.empty? %>
         <% @item.each do |item| %>
           <li class='list'>
-            <%= link_to "#" do %><%#ここは詳細ページ実装後#%>
+            <%= link_to item_path(item.id) do %><%#ここは詳細ページ実装後#%>
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,13 +29,18 @@
 
     
     <% if @item.present? == false || user_signed_in? %>   <%# 未ログインユーザーとSold out時は、ボタンを表示しない %>
-      <% if current_user.id == @item.user_id %>   <%# 現在ログインしているユーザーが商品の出品者であれば %>
+      
+      <%# 現在ログインしているユーザーが商品の出品者であれば %>
+      <% if current_user.id == @item.user_id %>   
         <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
         <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-      <% else %>   <%# 商品が売れていないかつ、ログインしているユーザーと出品しているユーザーが他者の場合 %>
+       
+      <%# 商品が売れていないかつ、ログインしているユーザーと出品しているユーザーが他者の場合 %>
+      <% else %> 
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
       <%end%>
+      
     <% end %>
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
     </div>
 
     
-    <% if @item.present? == false || user_signed_in? %>   <%# 未ログインユーザーとSold out時は、ボタンを表示しない %>
+    <% if user_signed_in? %>   <%# 未ログインユーザーとSold out時は、ボタンを表示しない %>
       
       <%# 現在ログインしているユーザーが商品の出品者であれば %>
       <% if current_user.id == @item.user_id %>   
@@ -40,7 +40,7 @@
       <% else %> 
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
       <%end%>
-      
+
     <% end %>
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,13 +28,14 @@
     </div>
 
     
-    <% if @item.present? == false || user_signed_in? == false %>   <%# 未ログインユーザーとSold out時は、ボタンを表示しない %>
-    <% elsif user_signed_in? && current_user.id == @item.user_id %>   <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合 %>
-      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-      <p class='or-text'>or</p>
-      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <% elsif user_signed_in? %>   <%# 商品が売れていないかつ、ログインしているユーザーと出品しているユーザーが他者の場合 %>
-      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% if @item.present? == false || user_signed_in? %>   <%# 未ログインユーザーとSold out時は、ボタンを表示しない %>
+      <% if current_user.id == @item.user_id %>   <%# 現在ログインしているユーザーが商品の出品者であれば %>
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% else %>   <%# 商品が売れていないかつ、ログインしているユーザーと出品しているユーザーが他者の場合 %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <%end%>
     <% end %>
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,66 +4,67 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+
+      <%# 商品が売れている場合は、sold outを表示 %>
+      <% unless @item.present? %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
+      <%# //商品が売れている場合は、sold outを表示 %>
+
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.burden.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    
+    <% if @item.present? == false || user_signed_in? == false %>   <%# 未ログインユーザーとSold out時は、ボタンを表示しない %>
+    <% elsif user_signed_in? && current_user.id == @item.user_id %>   <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合 %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% elsif user_signed_in? %>   <%# 商品が売れていないかつ、ログインしているユーザーと出品しているユーザーが他者の場合 %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.state.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery_period.name %></td>
         </tr>
       </tbody>
     </table>
@@ -102,9 +103,9 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href=“#” class=‘another-item’><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <%# 詳細ページで表示されている商品のカテゴリー名を表示(遷移は未対応) %>
+  <a href=“#” class=‘another-item’><%= @item.category.name %>をもっと見る</a>
+  <%# //詳細ページで表示されている商品のカテゴリー名を表示 %>
 </div>
 
 <%= render "shared/footer" %>


### PR DESCRIPTION
# What
- 商品詳細ページへの遷移実装
- ログイン状態の出品者のみ、「編集・削除ボタン」を表示
  - [上記gyazo](https://gyazo.com/429cefc1f9c3e4b75b4c78445f4d5df5)
- ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示
- コメントしたaタグの表記を商品カテゴリーに変更
  - [上記gyazo](https://gyazo.com/96bbdc1aa23f6ae7909b43ac2a7fa631)
- ログアウト状態のユーザーでも、商品詳細表示ページを閲覧
- ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されない
  - [上記gyazo](https://gyazo.com/76e9e98a7737ba661b43bc8d435e1826)
- ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されない(機能は未実装)
- 売却済みの商品は、画像上に「sold out」の文字が表示(機能は未実装)
  - [上記gyazo](https://gyazo.com/a27490cd889955d11088c5e4c0ad626b)

# Why
- 商品詳細表示機能実装のため