### PR TITLE
item:destroy機能実装&不正アクセス制限修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: [:edit, :update, :show] #重複処理をまとめる
   before_action :authenticate_user!, only: [:new, :edit] #ログアウト状態のユーザーがアクセスするとログイン画面へ遷移
-  before_action :move_to_index, except: [:index, :show] #url直接記入の不正アクセス防止
+  before_action :move_to_index, only: [:edit] #url直接記入の不正アクセス防止
 
   def index
     @items = Item.all.includes(:user).order('created_at DESC')
@@ -32,6 +32,9 @@ class ItemsController < ApplicationController
   end
 
   def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
   end
 
   def show

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,8 +33,12 @@ class ItemsController < ApplicationController
 
   def destroy
     item = Item.find(params[:id])
-    item.destroy
-    redirect_to root_path
+    if user_signed_in? && (current_user.id == item.user_id)
+      item.destroy
+      redirect_to root_path
+    else
+      redirect_to action: :index 
+    end
   end
 
   def show

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:edit, :update, :show] #重複処理をまとめる
-  before_action :authenticate_user!, only: [:new, :edit] #ログアウト状態のユーザーがアクセスするとログイン画面へ遷移
-  before_action :move_to_index, only: [:edit] #url直接記入の不正アクセス防止
+  before_action :set_item, only: [:edit, :update, :show] # 重複処理をまとめる
+  before_action :authenticate_user!, only: [:new, :edit] # ログアウト状態のユーザーがアクセスするとログイン画面へ遷移
+  before_action :move_to_index, only: [:edit] # url直接記入の不正アクセス防止
 
   def index
     @items = Item.all.includes(:user).order('created_at DESC')
@@ -37,7 +37,7 @@ class ItemsController < ApplicationController
       item.destroy
       redirect_to root_path
     else
-      redirect_to action: :index 
+      redirect_to action: :index
     end
   end
 
@@ -54,13 +54,10 @@ class ItemsController < ApplicationController
   def move_to_index
     item = Item.find(params[:id].to_i)
     # sold out時に直接urlを叩いたらindexへ遷移するコードは未記入
-    unless user_signed_in? && (current_user.id == item.user_id)
-      redirect_to action: :index 
-    end
+    redirect_to action: :index unless user_signed_in? && (current_user.id == item.user_id)
   end
 
   def set_item
     @item = Item.find(params[:id])
   end
-  
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:edit, :update, :show] # 重複処理をまとめる
-  before_action :authenticate_user!, only: [:new, :edit] # ログアウト状態のユーザーがアクセスするとログイン画面へ遷移
+  before_action :set_item, only: [:edit, :update, :show, :destroy] # 重複処理をまとめる
+  before_action :authenticate_user!, except: [:index, :show] # ログアウト状態のユーザーがアクセスするとログイン画面へ遷移
   before_action :move_to_index, only: [:edit] # url直接記入の不正アクセス防止
 
   def index
@@ -32,13 +32,8 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    item = Item.find(params[:id])
-    if user_signed_in? && (current_user.id == item.user_id)
-      item.destroy
-      redirect_to root_path
-    else
-      redirect_to action: :index
-    end
+    @item.destroy if current_user.id == @item.user_id
+    redirect_to root_path
   end
 
   def show

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -34,7 +34,7 @@
       <% if current_user.id == @item.user_id %>   
         <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
-        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+        <%= link_to '削除', item_path, method: :delete, class:'item-destroy' %>
        
       <%# 商品が売れていないかつ、ログインしているユーザーと出品しているユーザーが他者の場合 %>
       <% else %> 


### PR DESCRIPTION
# What
- controllerのdestroy記述
- views/items/edit内の削除機能記述にてルートパスを設定
  - [gyazo](https://gyazo.com/37f2eca502acfbb4dafb86bb3c1c8678)
- move_to_indexのonlyを変更

# Why
- 商品削除機能の実装のため
- 商品が空の状態でnewを行った際、move_to_indexが引っかかったため、onlyの記述に変更